### PR TITLE
go fmt, go vet, cleanup

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -13,7 +13,7 @@ var cmdChallenge = &Command{
 	Long: `
 Fetch challenge <challenge-name> from server.
 
-All needed files will be saved in a directory named <challende-name>.
+All needed files will be saved in a directory named <challenge-name>.
 	`,
 }
 
@@ -40,10 +40,10 @@ func cloneChallenge(cmd *Command, args []string) {
 	c := exec.Command("git", "clone", repo)
 	outstr, err := c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to fetch challenge <"+args[0]+">.")
-		fmt.Fprintln(os.Stderr, "Reason: "+string(outstr)) // TODO: Remove message from production tool
+		fmt.Fprintf(os.Stderr, "Failed to fetch challenge <%s>.\n", args[0])
+		fmt.Fprintf(os.Stderr, "Reason: %s\n", outstr) // TODO: Remove message from production tool
 		os.Exit(2)
 	} else {
-		fmt.Println(os.Stdout, "Successfully fetched into directory "+args[0])
+		fmt.Printf("Successfully fetched into directory %s\n", args[0])
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -46,7 +45,7 @@ func findConfigurationRecursive(dirName, limit string) (*Config, error) {
 		var config Config
 		err = yaml.Unmarshal(rawConfig, &config)
 		if err != nil {
-			fmt.Printf("Error parsing " + fileNames[i] + ": " + err.Error() + "\n")
+			fmt.Fprintf(os.Stderr, "Error parsing %s: %s\n", fileNames[i], err.Error())
 			continue
 		}
 		return &config, nil
@@ -57,7 +56,7 @@ func findConfigurationRecursive(dirName, limit string) (*Config, error) {
 		return nil, err
 	}
 	if abs == limit {
-		return nil, errors.New("Reached " + limit + " before finding a valid configuration file.")
+		return nil, fmt.Errorf("reached %s before finding a valid configuration file.", limit)
 	}
 
 	return findConfigurationRecursive(path.Join(dirName, ".."), limit)

--- a/login.go
+++ b/login.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"encoding/base64"
 	"fmt"
-	"github.com/coduno/netrc"
-	"github.com/howeyc/gopass"
-	"github.com/mitchellh/go-homedir"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/coduno/netrc"
+	"github.com/howeyc/gopass"
+	"github.com/mitchellh/go-homedir"
 )
 
 var cmdLogin = &Command{
@@ -39,7 +40,7 @@ func runLogin(cmd *Command, args []string) {
 	path, _ := homedir.Expand("~/.ssh/id_rsa.pub")
 	keyfile, err := os.Open(path)
 	if err != nil {
-		fmt.Println("Please provide your public RSA key at " + path)
+		fmt.Printf("Please provide your public RSA key at %s\n", path)
 		os.Exit(1)
 	}
 
@@ -67,14 +68,14 @@ func runLogin(cmd *Command, args []string) {
 		netrcx, err := netrc.Parse()
 
 		if err != nil {
-			fmt.Printf("Failed to read netrc:", err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to read netrc: %s", err.Error())
 		}
 
 		netrcx.Entries["git.cod.uno"] = netrc.Entry{Login: username, Password: string(body)}
 
 		err = netrcx.Save()
 		if err != nil {
-			fmt.Printf("Failed to save netrc:", err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to save netrc: %s", err.Error())
 		}
 	} else {
 		fmt.Print(string(body))

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ var commands = []*Command{
 	cmdRun,
 	cmdPrepare,
 	cmdPush,
-	cmdSsh,
+	cmdSSH,
 }
 
 var exitStatus = 0

--- a/ssh.go
+++ b/ssh.go
@@ -6,14 +6,14 @@ import (
 	"os/exec"
 )
 
-var cmdSsh = &Command{
-	Run:       runSsh,
+var cmdSSH = &Command{
+	Run:       runSSH,
 	UsageLine: "ssh",
 	Short:     "connects to Coduno via ssh",
 	Long:      `This is helpful if you want to check whether Coduno has your public key.`,
 }
 
-func runSsh(cmd *Command, args []string) {
+func runSSH(cmd *Command, args []string) {
 	c := exec.Command("ssh", "git@git.cod.uno")
 
 	c.Stdin = os.Stdin


### PR DESCRIPTION
- run `go fmt`
- fix `go vet` complaints
- fix a typo
- use format strings instead of string concatenation
- write errors to stderr
